### PR TITLE
Fix stale lab-numbering references and missing conda deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ No local installation needed. You only need a Google account.
 **1. Upload the notebook**
 
 - Go to [Google Colab](https://colab.research.google.com/)
-- Click `File > Upload notebook` and upload the `.ipynb` file from the lab folder (e.g. `lab0/lab1.ipynb`)
+- Click `File > Upload notebook` and upload the `.ipynb` file from the lab folder (e.g. `lab1/lab1.ipynb`)
 
 **2. Install required packages**
 
@@ -86,7 +86,7 @@ python -m ipykernel install --user --name py-cb2110 --display-name "Python 3 (CB
 **4. Open the notebook in VS Code**
 
 - Open VS Code and open the cloned `CB2110` folder (`File > Open Folder`)
-- Navigate to the lab folder (e.g. `lab0/`) and open `lab1.ipynb`
+- Navigate to the lab folder (e.g. `lab1/`) and open `lab1.ipynb`
 - In the top-right corner of the notebook, click **Select Kernel** and choose **Python 3 (CB2110)**
 - You can now run cells and answer questions directly in the notebook
 

--- a/config_python.yml
+++ b/config_python.yml
@@ -9,3 +9,5 @@ dependencies:
   - pandas
   - numpy
   - matplotlib
+  - seaborn
+  - missingno

--- a/lab0/lab0 Database.ipynb
+++ b/lab0/lab0 Database.ipynb
@@ -1,154 +1,38 @@
 {
-  "cells": [
-    {
-      "cell_type": "raw",
-      "metadata": {},
-      "source": [
-        "---\n",
-        "title: Lab 1\n",
-        "date: last-modified\n",
-        "format:\n",
-        "  html:\n",
-        "    toc: true\n",
-        "    code-fold: true\n",
-        "    theme: lumen\n",
-        "---"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": "## Setup\n\n**Run the cell below before starting the lab.**\n\n- **Local (VS Code):** If you have set up the `py-cb2110` conda environment, the packages are already installed \u2014 you can skip or ignore any output from this cell.\n- **Google Colab:** Run this cell first to install the required packages.",
-      "metadata": {}
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Install required packages (safe to run locally too \u2014 skips already-installed packages)\n",
-        "!pip install pandas numpy matplotlib --quiet"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Welcome everyone to lab one. This worksheet will guide you to everything that you need including instructions, the questions and definitely the bonus questions for your extra scores. Before we start with anything, please fill in your information here so we can give you nice some nice scores later. \n",
-        "\n",
-        "- Member1:\n",
-        "- Member2: \n",
-        "- Contact email: \n",
-        "\n",
-        "There will be ten questions and three bonus questions for you to answer. Please try to elaborate this exercise with the lectures from the first weeks on mass spectrometry. The goal of this lab is for you to enjoy mass spectrometry as it is a major technology in the field of proteomics. In other words, it is not that simple to understand it with in a few minutes but we are here to explore them all together. Nevertheless, we try to reduce several steps into just a simple exercise. \n",
-        "\n",
-        "## Intended learning outcomes (ILOs)\n",
-        "\n",
-        "On completion of the lab, the student should be able to:\n",
-        "\n",
-        "1. Demonstrate understandings and insights in mass spectrometry\n",
-        "2. Retrieve open access mass spectrometry data\n",
-        "3. Access organism proteome from database \n",
-        "4. Identify the relevant issues of complexity in high-throughput data structure from mass spectrometry\n",
-        "5. Demonstrate capacity to store and handle high throughput data with efficiency \n",
-        "\n",
-        "## Let's start! \n",
-        "\n",
-        "In this lab, we will explore mass spectrometry proteomics database where we can find the data and explore them. There are many ways to do proteomics analysis but we will discuss based on the data that we see. One does not need to code here but we will explain how to do it together. \n",
-        "\n",
-        "<em>Let's begin by visiting [ProteomeCentral](https://proteomecentral.proteomexchange.org/), a central hub for searching mass spectrometry (MS) data repositories. Here, you can browse and access datasets from various proteomics resources such as PRIDE, PeptideAtlas, MassIVE, and more. That's because ProteomeCentral  belongs to [ProteomExchange](https://www.proteomexchange.org/) wihich is a centralized and standardized framework for all scientist working with proteomics mass spectrometry. Well, it does not keep the data itself. It just provides a link to where one can find the database and accession id easily. Of course, everything that one can see here is public. We are allowed to download and play with this data as we would like. Maybe at some point of your career time, one may publish MS data on ProteomExchange. \n",
-        "\n",
-        "Try making a simple search from there. One can pick several parameters of interests including type of samples and type of MS experiment or machine.</em>\n",
-        "\n",
-        "## Q1. \n",
-        "**Pick one dataset from there. What is there dataset identifier? Summarise the experiment in a short paragraph (<100 words). What do we expect to find from this MS dataset?** \n",
-        "```\n",
-        "Ans.\n",
-        "```\n",
-        "## Q2.\n",
-        "**What samples were used and located in the organism/s in this experiment?**\n",
-        "```\n",
-        "Ans. \n",
-        "```\n",
-        "## Q3. \n",
-        "**What is the model of the instrument? What is its set-up for example DIA or DDA? Is it labelled or labelled-free quantification?**\n",
-        "```\n",
-        "Ans.\n",
-        "```\n",
-        "## Q4.\n",
-        "**Do we see the data according to the information on the submission or the article? What else are missing?** \n",
-        "```\n",
-        "Ans. \n",
-        "```\n",
-        "## Q5.\n",
-        "**Does it include SDRF file there? Why do we need an SDRF file?**\n",
-        "```\n",
-        "Ans. \n",
-        "```\n",
-        "## Q6. \n",
-        "<em>Next step, peptide spectral matching (PSM) need a proteome to search against your experiment. Please just go to Uniprot.</em> **What proteome would you download from Uniprot? How many proteins are there?**\n",
-        "```\n",
-        "Ans.\n",
-        "```\n",
-        "## Q7. \n",
-        "**Does the number of proteins in the proteome impact the search? How (Hint: Lukas's lecture) ?**\n",
-        "```\n",
-        "Ans. \n",
-        "```\n",
-        "## Q8.\n",
-        "<em>At this step, you are able to do PSM. We can do it with a simple tool call [quantms](https://docs.quantms.org/latest/index.html). One can try running it with the tutorial [here](https://github.com/thanadol-git/quantms_example). **In this lab, we will skip this step but one may try to strenghten skill in mass spectrometry.** It may take a few resources as MS data are usually huge for any local computer</em> **Is there an alternative for quantms? How does the article work with PSM?**\n",
-        "```\n",
-        "Ans. \n",
-        "```\n",
-        "## Q9. \n",
-        "**Why do we need to add target decoys? How do they work?**\n",
-        "```\n",
-        "Ans. \n",
-        "```\n",
-        "## Q10.\n",
-        "**Can we search with proteomes from more than one organism? How?**\n",
-        "```\n",
-        "Ans. \n",
-        "```\n",
-        "Hooray! Once you finish answering the questions, please render this markdown to pdf and upload it on Canvas.\n",
-        "\n",
-        "\n",
-        "## Bonus questions\n",
-        "### BQ1\n",
-        "**How does peptide identification step in Q8. work?**  \n",
-        "```\n",
-        "Ans. \n",
-        "```\n",
-        "\n",
-        "### BQ2\n",
-        "**How can we run mass spectrometry experiments sustainably?**\n",
-        "```\n",
-        "Ans. \n",
-        "```\n",
-        "\n",
-        "### BQ3. \n",
-        "**What is the database containing adventitious proteins? Why are these proteins important?**\n",
-        "```\n",
-        "Ans.\n",
-        "```\n",
-        "\n",
-        "- - -\n",
-        "\n",
-        "## References\n",
-        "\n",
-        "<em>https://github.com/bigbio/proteomics-sample-metadata</em>\n",
-        "<em>https://pwilmart.github.io/blog/2020/09/19/shotgun-quantification-part2</em>\n",
-        "<em>https://github.com/thanadol-git/quantms_example.git</em>"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "name": "py-cb2110",
-      "language": "python",
-      "display_name": "Python 3 (CB2110)"
-    }
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": "---\ntitle: Lab 0\ndate: last-modified\nformat:\n  html:\n    toc: true\n    code-fold: true\n    theme: lumen\n---"
   },
-  "nbformat": 4,
-  "nbformat_minor": 4
+  {
+   "cell_type": "markdown",
+   "source": "## Setup\n\n**Run the cell below before starting the lab.**\n\n- **Local (VS Code):** If you have set up the `py-cb2110` conda environment, the packages are already installed — you can skip or ignore any output from this cell.\n- **Google Colab:** Run this cell first to install the required packages.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install required packages (safe to run locally too — skips already-installed packages)\n",
+    "!pip install pandas numpy matplotlib --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "Welcome everyone to lab zero. This worksheet will guide you to everything that you need including instructions, the questions and definitely the bonus questions for your extra scores. Before we start with anything, please fill in your information here so we can give you nice some nice scores later. \n\n- Member1:\n- Member2: \n- Contact email: \n\nThere will be ten questions and three bonus questions for you to answer. Please try to elaborate this exercise with the lectures from the first weeks on mass spectrometry. The goal of this lab is for you to enjoy mass spectrometry as it is a major technology in the field of proteomics. In other words, it is not that simple to understand it with in a few minutes but we are here to explore them all together. Nevertheless, we try to reduce several steps into just a simple exercise. \n\n## Intended learning outcomes (ILOs)\n\nOn completion of the lab, the student should be able to:\n\n1. Demonstrate understandings and insights in mass spectrometry\n2. Retrieve open access mass spectrometry data\n3. Access organism proteome from database \n4. Identify the relevant issues of complexity in high-throughput data structure from mass spectrometry\n5. Demonstrate capacity to store and handle high throughput data with efficiency \n\n## Let's start! \n\nIn this lab, we will explore mass spectrometry proteomics database where we can find the data and explore them. There are many ways to do proteomics analysis but we will discuss based on the data that we see. One does not need to code here but we will explain how to do it together. \n\n<em>Let's begin by visiting [ProteomeCentral](https://proteomecentral.proteomexchange.org/), a central hub for searching mass spectrometry (MS) data repositories. Here, you can browse and access datasets from various proteomics resources such as PRIDE, PeptideAtlas, MassIVE, and more. That's because ProteomeCentral  belongs to [ProteomExchange](https://www.proteomexchange.org/) wihich is a centralized and standardized framework for all scientist working with proteomics mass spectrometry. Well, it does not keep the data itself. It just provides a link to where one can find the database and accession id easily. Of course, everything that one can see here is public. We are allowed to download and play with this data as we would like. Maybe at some point of your career time, one may publish MS data on ProteomExchange. \n\nTry making a simple search from there. One can pick several parameters of interests including type of samples and type of MS experiment or machine.</em>\n\n## Q1. \n**Pick one dataset from there. What is there dataset identifier? Summarise the experiment in a short paragraph (<100 words). What do we expect to find from this MS dataset?** \n```\nAns.\n```\n## Q2.\n**What samples were used and located in the organism/s in this experiment?**\n```\nAns. \n```\n## Q3. \n**What is the model of the instrument? What is its set-up for example DIA or DDA? Is it labelled or labelled-free quantification?**\n```\nAns.\n```\n## Q4.\n**Do we see the data according to the information on the submission or the article? What else are missing?** \n```\nAns. \n```\n## Q5.\n**Does it include SDRF file there? Why do we need an SDRF file?**\n```\nAns. \n```\n## Q6. \n<em>Next step, peptide spectral matching (PSM) need a proteome to search against your experiment. Please just go to Uniprot.</em> **What proteome would you download from Uniprot? How many proteins are there?**\n```\nAns.\n```\n## Q7. \n**Does the number of proteins in the proteome impact the search? How (Hint: Lukas's lecture) ?**\n```\nAns. \n```\n## Q8.\n<em>At this step, you are able to do PSM. We can do it with a simple tool call [quantms](https://docs.quantms.org/latest/index.html). One can try running it with the tutorial [here](https://github.com/thanadol-git/quantms_example). **In this lab, we will skip this step but one may try to strenghten skill in mass spectrometry.** It may take a few resources as MS data are usually huge for any local computer</em> **Is there an alternative for quantms? How does the article work with PSM?**\n```\nAns. \n```\n## Q9. \n**Why do we need to add target decoys? How do they work?**\n```\nAns. \n```\n## Q10.\n**Can we search with proteomes from more than one organism? How?**\n```\nAns. \n```\nHooray! Once you finish answering the questions, please render this markdown to pdf and upload it on Canvas.\n\n\n## Bonus questions\n### BQ1\n**How does peptide identification step in Q8. work?**  \n```\nAns. \n```\n\n### BQ2\n**How can we run mass spectrometry experiments sustainably?**\n```\nAns. \n```\n\n### BQ3. \n**What is the database containing adventitious proteins? Why are these proteins important?**\n```\nAns.\n```\n\n- - -\n\n## References\n\n<em>https://github.com/bigbio/proteomics-sample-metadata</em>\n<em>https://pwilmart.github.io/blog/2020/09/19/shotgun-quantification-part2</em>\n<em>https://github.com/thanadol-git/quantms_example.git</em>"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "name": "py-cb2110",
+   "language": "python",
+   "display_name": "Python 3 (CB2110)"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/lab1/README.md
+++ b/lab1/README.md
@@ -1,6 +1,6 @@
 # Lab 1 (quantmsdiann) — Running a DIA proteomics pipeline with quantmsdiann on GitHub Codespaces
 
-In lab 1 you analyzed a table of already-processed mass-spec results. In this lab you will
+In lab 0 you analyzed a table of already-processed mass-spec results. In this lab you will
 generate that kind of table yourself, by running the actual
 [quantmsdiann](https://github.com/bigbio/quantmsdiann) pipeline (Nextflow + DIA-NN) on
 DIA mzML files and a FASTA protein database — no local installation required, everything
@@ -176,7 +176,7 @@ amount of accuracy for speed/memory.
 
 Look inside `results/` for:
 - The DIA-NN search report(s)
-- An MSstats-format quantification table (similar to what you used in lab 2)
+- An MSstats-format quantification table (similar to what you'll use in lab 2)
 - A MultiQC report summarizing run-level QC metrics
 
 ## Questions (draft — to be finalized)


### PR DESCRIPTION
- README.md: fix broken example paths (lab0/lab1.ipynb doesn't exist; the notebook lives in lab1/).
- lab1/README.md: fix self-contradictory lab references left over from the lab1->lab0 / lab2_qms->lab1 rename ("lab 1" now means lab0's content; the MSstats table is used in the upcoming lab2, not a past one).
- lab0: update stale "Lab 1" title/intro text to "Lab 0" to match its new folder name.
- config_python.yml: add seaborn and missingno, which lab2/lab2.ipynb imports but the env spec didn't include.